### PR TITLE
Bugly sometimes doesn't upload crash report.

### DIFF
--- a/Plugins/Bugly/Source/BuglySDK/BuglySDK_UPL.xml
+++ b/Plugins/Bugly/Source/BuglySDK/BuglySDK_UPL.xml
@@ -15,6 +15,10 @@
 		<copyDir src="$S(PluginDir)/Android/libs/$S(Architecture)/" dst="$S(BuildDir)/libs/$S(Architecture)/" />
 	</resourceCopies>
 
+	<soLoadLibrary>
+		<loadLibrary name="bugly" failmsg="bugly library not loaded and required!"/>
+	</soLoadLibrary>
+
 	<proguardAdditions>
 		<insert>
 			-dontwarn com.tencent.bugly.**


### PR DESCRIPTION
Reason&Solution: Load libBugly.so before libUE4.so